### PR TITLE
修复php8.0+中SMTP配置测试出现报错

### DIFF
--- a/libs/TestAction.php
+++ b/libs/TestAction.php
@@ -339,7 +339,7 @@ class TestAction extends Typecho\Widget implements Widget\ActionInterface
         $mail->CharSet = 'utf-8';
         $mail->setFrom($this->_pluginOption->from, $this->_pluginOption->from_name);
         var_dump($this->request->get('to'));
-        $mail->addAddress($this->request->get('to'), $this->request->getArray('toName'));
+        $mail->addAddress($this->request->get('to'), $this->request->get('toName'));
         $mail->Body = $msg;
 
 


### PR DESCRIPTION
已测试以下php版本，均为正常
php8.1.5
php8.0.18
php7.4.29