### PR TITLE
Fix outdated author url

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -28,7 +28,7 @@ const __TYPECHO_PLUGIN_NOTICE_VERSION__ = '1.0.6';
  * @package Notice
  * @author <strong style="color:#28B7FF;font-family: 楷体;">Rainshaw</strong>
  * @version 1.0.6
- * @link https://github.com/RainshawGao
+ * @link https://github.com/Rainshaw
  * @since 1.2.0
  */
 class Plugin implements PluginInterface


### PR DESCRIPTION
作者改了名字，带仓库名的 url GitHub会自动跳转，但是单独的用户url，GitHub不会跳转。这带来的问题就是如下区域，用户点击后是一个 404 页面，不知道的还以为作者删库跑路了……
![图片](https://github.com/Rainshaw/Typecho-Plugin-Notice/assets/13460812/bbb21d87-7534-453d-9c68-3fc9f0f2b031)
